### PR TITLE
gcc build warning, switched to catch a reference

### DIFF
--- a/pping.cpp
+++ b/pping.cpp
@@ -172,7 +172,7 @@ static inline tsInfo* getTStm(const std::string& key)
     try {
         tsInfo* ti = tsTbl.at(key);
         return ti;
-    } catch (std::out_of_range) {
+    } catch (std::out_of_range&) {
         return nullptr;
     }
 }


### PR DESCRIPTION
Error message when building:

```
09:41:25 zeus:(master)~/dev/pping$ make
g++ -I/home/bcall/src/libtins/include -std=c++14 -g -O3 -Wall -o pping pping.cpp -L/home/bcall/src/libtins/lib -ltins -lpcap
pping.cpp: In function ‘tsInfo* getTStm(const std::string&)’:
pping.cpp:175:19: warning: catching polymorphic type ‘class std::out_of_range’ by value [-Wcatch-value=]
  175 |     } catch (std::out_of_range) {
      |                   ^~~~~~~~~~~~
09:41:28 zeus:(master)~/dev/pping$ gcc --version
gcc (GCC) 13.2.1 20230728 (Red Hat 13.2.1-1)
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
